### PR TITLE
LCP対策:使用していないCSSファイルの削除

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -41,6 +41,8 @@ module.exports = {
           format: {
             comments: false,
           },
+          // 使用していないCSSファイルの削除
+          ignore: ['/a950528aa4c9e8db.css/'],
         },
         extractComments: false,
       }),

--- a/next.config.js
+++ b/next.config.js
@@ -41,10 +41,8 @@ module.exports = {
           format: {
             comments: false,
           },
-          // 使用していないCSSファイルの除外
-          exclude: ['/a950528aa4c9e8db.css/'],
         },
-        extractComments: false,
+        exclude: /\/_next\/static\/css\/a950528aa4c9e8db\.css/, // 不要なCSSファイルの除外
       }),
     ]
 

--- a/next.config.js
+++ b/next.config.js
@@ -41,8 +41,8 @@ module.exports = {
           format: {
             comments: false,
           },
-          // 使用していないCSSファイルの削除
-          ignore: ['/a950528aa4c9e8db.css/'],
+          // 使用していないCSSファイルの除外
+          exclude: ['/a950528aa4c9e8db.css/'],
         },
         extractComments: false,
       }),

--- a/next.config.js
+++ b/next.config.js
@@ -43,6 +43,7 @@ module.exports = {
           },
         },
         exclude: /\/_next\/static\/css\/a950528aa4c9e8db\.css/, // 不要なCSSファイルの除外
+        extractComments: false, // コメントを削除
       }),
     ]
 


### PR DESCRIPTION
# 概要
Largest Contentful Paint(LCP)対策
- 使用していないcssファイルを[exclude](https://www.npmjs.com/package/terser-webpack-plugin)するように設定
<img width="1440" alt="スクリーンショット 2023-08-19 10 45 05" src="https://github.com/yud0uhu/my-blog/assets/60646787/d1fedb70-b413-4ca8-b190-842d2864f47a">


https://developer.chrome.com/docs/lighthouse/performance/unused-javascript/?utm_source=lighthouse&utm_medium=devtools

改善前
![image](https://github.com/yud0uhu/my-blog/assets/60646787/779a0ae8-b7e9-4c3a-b38e-117ea4bc479e)

改善後
<img width="1440" alt="スクリーンショット 2023-08-19 10 55 13" src="https://github.com/yud0uhu/my-blog/assets/60646787/7ccbf936-f962-4fee-817d-01572b2ccc29">
